### PR TITLE
Change compile keyword to implementation for Gradle 7+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thing-it/cordova-plugin-photo-viewer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thing-it/cordova-plugin-photo-viewer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "This plugin is intended to show a picture from an URL into a Photo Viewer with zoom features.",
   "cordova": {
     "id": "@thing-it/cordova-plugin-photo-viewer",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-photo-viewer" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-photo-viewer" version="1.3.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>PhotoViewer</name>
     <description>This plugin is intended to show a picture from an URL into a Photo Viewer with zoom features.</description>
     <js-module name="PhotoViewer" src="www/PhotoViewer.js">

--- a/src/android/photoviewer.gradle
+++ b/src/android/photoviewer.gradle
@@ -5,8 +5,8 @@ repositories{
 }
 
 dependencies {
-   compile 'com.github.chrisbanes.photoview:library:1.2.4'
-   compile 'com.squareup.picasso:picasso:2.5.2'
+   implementation 'com.github.chrisbanes.photoview:library:1.2.4'
+   implementation 'com.squareup.picasso:picasso:2.5.2'
 }
 
 android {


### PR DESCRIPTION
With the upgrade to [cordova-android 11](https://cordova.apache.org/announcements/2022/07/12/cordova-android-release-11.0.0.html) the Android builds are now done with Gradle 7.4.2. Gradle removed the `compile` keyword with version 7.x. As [described by Gradle](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal), the keyword is to be replaced by `implementation`.